### PR TITLE
fix: remove modulename_link as it doesn't link to an existing Totara doc

### DIFF
--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -118,7 +118,6 @@ $string['modify'] = 'Modify';
 $string['modulename'] = 'Custom certificate';
 $string['modulenameplural'] = 'Custom certificates';
 $string['modulename_help'] = 'This module allows for the dynamic generation of PDF certificates.';
-$string['modulename_link'] = 'Custom_certificate_module';
 $string['mycertificates'] = 'My certificates';
 $string['mycertificatesdescription'] = 'These are the certificates you have been issued by either email or downloading manually.';
 $string['name'] = 'Name';


### PR DESCRIPTION
String keys ending with '_link' are reserved. If 'modulename_link' in component 'mod_customcert' is used to link to Totara documentation then it should be added to the whitelist, otherwise it should be renamed.
