### PR TITLE
mod_customcert Fix bug due to totara fastpath in get_in_or_equal

### DIFF
--- a/classes/certificate.php
+++ b/classes/certificate.php
@@ -251,10 +251,12 @@ class certificate {
         // Get the conditional SQL.
         list($conditionssql, $conditionsparams) = self::get_conditional_issues_sql($cm, $groupmode);
 
-        // If it is empty then return an empty array.
-        if (empty($conditionsparams)) {
-            return array();
-        }
+        // WR386270 - totara returns an empty array of params when given an integer params array to get in or equal
+        //
+        // // If it is empty then return an empty array.
+        // if (empty($conditionsparams)) {
+        //     //return array();
+        // }
 
         // Add the conditional SQL and the customcertid to form all used parameters.
         $allparams = $conditionsparams + array('customcertid' => $customcertid);
@@ -292,10 +294,11 @@ class certificate {
         // Get the conditional SQL.
         list($conditionssql, $conditionsparams) = self::get_conditional_issues_sql($cm, $groupmode);
 
-        // If it is empty then return 0.
-        if (empty($conditionsparams)) {
-            return 0;
-        }
+        // WR386270 - totara returns an empty array of params when given an integer params array to get in or equal
+        // // If it is empty then return 0.
+        // if (empty($conditionsparams)) {
+        //     //return 0;
+        // }
 
         // Add the conditional SQL and the customcertid to form all used parameters.
         $allparams = $conditionsparams + array('customcertid' => $customcertid);


### PR DESCRIPTION
Upstreaming a bug fix, see description below:

Totara's get in or equal implementation has a "fast path" for integer parameters, instead of using param substitution and returning the params array it explodes the integers into an explicit IN query and returns an empty array.

The mod customcert was assuming that a lack of a conditions param from this get in or equal call indicated a empty result and shortcutting the behaviour. This lead to the behaviour of shortcutting incorrectly when installed on totara.

To fix the behaviour, we simply avoid the the shortcutting and make the SQL parameter call anyway, resolving the underlying issue.